### PR TITLE
🔨 [tuning] Improved documentations; removed deprecated IgKnite configurations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup mdbook
         uses: peaceiris/actions-mdbook@v1
@@ -31,16 +31,16 @@ jobs:
           mdbook-version: 'latest'
         
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4
 
       - name: Build
         run: mdbook build
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './book'
           
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/src/development.md
+++ b/src/development.md
@@ -8,12 +8,9 @@ The [**preparation for hosting**](./hosting_preparation.md) sub-chapter discusse
 
 ## Code Style
 
-In order to maintain a proper and managed syntax, this project has two different packages:
-
-- [ruff](https://github.com/astral-sh/ruff) for linting and import organization
-- [black](https://github.com/psf/black) for formatting
+We have used [ruff](https://github.com/astral-sh/ruff) inside the entire project to ensure a proper and managed syntax. In this case, ruff powers both the linting and formatting of the codebase.
 
 ```bash
 # installation
-$ python3 -m pip install ruff black
+$ python3 -m pip install ruff
 ```

--- a/src/hosting_preparation.md
+++ b/src/hosting_preparation.md
@@ -75,7 +75,6 @@ We're assuming you're seeing something similar to this on your code editor:
 
 ```
 DISCORD_TOKEN=
-DISCORD_OWNER_ID=
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
 ```


### PR DESCRIPTION
## What's New

- [x] Removed black from the `src/development.md` file since it's no longer used in IgKnite's codebase.
- [x] Removed the mention of the deprecated `DISCORD_OWNER_ID` environment variable from `src/hosting_preparation.md`
- [x] Bumped the workflow dependencies for GitHub Actions deployment.